### PR TITLE
Add lazy, categorised logging facade with pluggable delegate 

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -48,6 +48,9 @@ kotlin {
     sourceSets.commonTest.dependencies {
         implementation(kotlin("test"))
     }
+    sourceSets.jvmMain.dependencies {
+        implementation(libs.slf4j.simple)
+    }
 }
 
 nordicNexusPublishing {

--- a/data/src/appleMain/kotlin/no/nordicsemi/kotlin/data/logger/NSLogDelegate.kt
+++ b/data/src/appleMain/kotlin/no/nordicsemi/kotlin/data/logger/NSLogDelegate.kt
@@ -1,0 +1,32 @@
+package no.nordicsemi.kotlin.data.logger
+
+import platform.Foundation.NSLog
+
+/**
+ * Default Apple-platforms [LogDelegate] that forwards entries to `NSLog`.
+ *
+ * Output format:
+ *
+ * ```
+ * [LEVEL] [Category] [source] message
+ * ```
+ *
+ * `NSLog` prefixes every line with a timestamp and process name on its own,
+ * so we only contribute the structured fields above. Any `%` characters in
+ * the resulting line are doubled before the call, since `NSLog` interprets
+ * them as `printf`-style format specifiers and would otherwise crash or
+ * print garbage on user input that contains a literal percent sign.
+ */
+class NSLogDelegate : LogDelegate {
+
+    override fun log(
+        category: LogCategory,
+        level: LogLevel,
+        source: String?,
+        message: () -> String,
+    ) {
+        val sourcePart = if (source != null) " [$source]" else ""
+        val line = "[${level.name}] [${category.name}]$sourcePart ${message()}"
+        NSLog(line.replace("%", "%%"))
+    }
+}

--- a/data/src/commonMain/kotlin/no/nordicsemi/kotlin/data/logger/LogCategory.kt
+++ b/data/src/commonMain/kotlin/no/nordicsemi/kotlin/data/logger/LogCategory.kt
@@ -1,0 +1,20 @@
+package no.nordicsemi.kotlin.data.logger
+
+/**
+ * A typed label identifying the layer or component that produced a log entry.
+ *
+ * Consumers are expected to declare their own enum implementing this interface,
+ * for example:
+ *
+ * ```
+ * enum class TransportLayer : LogCategory {
+ *     HCI, L2CAP, GATT, APPLICATION,
+ * }
+ * ```
+ *
+ * The [name] property is satisfied automatically by any Kotlin enum, so no
+ * extra boilerplate is required on the consumer side.
+ */
+interface LogCategory {
+    val name: String
+}

--- a/data/src/commonMain/kotlin/no/nordicsemi/kotlin/data/logger/LogDelegate.kt
+++ b/data/src/commonMain/kotlin/no/nordicsemi/kotlin/data/logger/LogDelegate.kt
@@ -1,0 +1,31 @@
+package no.nordicsemi.kotlin.data.logger
+
+/**
+ * Sink for log entries produced by a [Logger].
+ *
+ * Implementations decide *how* and *whether* to render an entry — through
+ * SLF4J, NSLog, OSLog, `println`, an in-memory ring buffer, a network sink,
+ * a test spy, etc. The library ships ready-to-use defaults for the JVM
+ * ([Slf4jLogDelegate]) and Apple ([NSLogDelegate]) targets; supplying your own
+ * is a one-liner thanks to SAM conversion:
+ *
+ * ```
+ * val logger = Logger(LogDelegate { category, level, source, message ->
+ *     println("[$level] [${category.name}] ${source ?: "-"}: ${message()}")
+ * })
+ * ```
+ *
+ * The [message] block is evaluated only after [Logger] has decided to forward
+ * the entry, so callers pay no string-construction cost for filtered-out
+ * levels. Implementations that further gate by their own configuration (e.g.
+ * SLF4J's per-logger thresholds) should also delay invoking [message] until
+ * after those checks.
+ */
+fun interface LogDelegate {
+    fun log(
+        category: LogCategory,
+        level: LogLevel,
+        source: String?,
+        message: () -> String,
+    )
+}

--- a/data/src/commonMain/kotlin/no/nordicsemi/kotlin/data/logger/LogLevel.kt
+++ b/data/src/commonMain/kotlin/no/nordicsemi/kotlin/data/logger/LogLevel.kt
@@ -1,0 +1,15 @@
+package no.nordicsemi.kotlin.data.logger
+
+/**
+ * Severity of a log entry.
+ *
+ * Declared in ascending order of importance, so [Logger] can compare values
+ * directly (`if (level >= minLevel)`) using the natural enum ordering.
+ */
+enum class LogLevel {
+    TRACE,
+    DEBUG,
+    INFO,
+    WARN,
+    ERROR,
+}

--- a/data/src/commonMain/kotlin/no/nordicsemi/kotlin/data/logger/Logger.kt
+++ b/data/src/commonMain/kotlin/no/nordicsemi/kotlin/data/logger/Logger.kt
@@ -1,0 +1,78 @@
+package no.nordicsemi.kotlin.data.logger
+
+/**
+ * Lazy, level-gated, source-aware logging facade.
+ *
+ * The logger itself is platform-agnostic; everything platform-specific lives
+ * inside the supplied [LogDelegate]. A single [Logger] can therefore be wired
+ * to any sink (SLF4J, NSLog, an in-memory buffer, a test spy, etc.).
+ *
+ * Three design pillars:
+ *
+ * - **Lazy.** Each `log(...)` call accepts `() -> String`; the message is
+ *   built only after the [minLevel] gate passes.
+ * - **Categorised.** Every entry carries a [LogCategory] (typically a
+ *   consumer-defined enum) so logs can be grouped by layer/component instead
+ *   of relying on free-form string tags.
+ * - **Source-aware.** Multiple producers (e.g. several connected devices)
+ *   may share one logger. The [source] argument is passed to the delegate as
+ *   a structured field, not embedded in the message body.
+ *
+ * @param delegate Sink that receives every entry that passes the [minLevel] gate.
+ * @param minLevel Minimum severity that will be forwarded. Entries below this
+ *                 level are dropped before [delegate] is invoked and before
+ *                 the message lambda is evaluated.
+ */
+class Logger(
+    private val delegate: LogDelegate,
+    private val minLevel: LogLevel = LogLevel.TRACE,
+) {
+
+    /** Forwards an entry to [delegate] iff [level] >= [minLevel]. */
+    fun log(
+        category: LogCategory,
+        level: LogLevel,
+        source: String? = null,
+        message: () -> String,
+    ) {
+        if (level >= minLevel) {
+            delegate.log(category, level, source, message)
+        }
+    }
+
+    fun trace(category: LogCategory, source: String? = null, message: () -> String) {
+        log(category, LogLevel.TRACE, source, message)
+    }
+
+    fun debug(category: LogCategory, source: String? = null, message: () -> String) {
+        log(category, LogLevel.DEBUG, source, message)
+    }
+
+    fun info(category: LogCategory, source: String? = null, message: () -> String) {
+        log(category, LogLevel.INFO, source, message)
+    }
+
+    fun warn(category: LogCategory, source: String? = null, message: () -> String) {
+        log(category, LogLevel.WARN, source, message)
+    }
+
+    fun error(category: LogCategory, source: String? = null, message: () -> String) {
+        log(category, LogLevel.ERROR, source, message)
+    }
+
+    /**
+     * Convenience for error logging with an attached [Throwable]. The stack
+     * trace is appended to the message so it survives transports (such as
+     * [NSLogDelegate]) that have no separate slot for exceptions.
+     */
+    fun error(
+        category: LogCategory,
+        throwable: Throwable,
+        source: String? = null,
+        message: () -> String,
+    ) {
+        log(category, LogLevel.ERROR, source) {
+            "${message()}\n${throwable.stackTraceToString()}"
+        }
+    }
+}

--- a/data/src/jvmMain/kotlin/no/nordicsemi/kotlin/data/logger/Slf4jLogDelegate.kt
+++ b/data/src/jvmMain/kotlin/no/nordicsemi/kotlin/data/logger/Slf4jLogDelegate.kt
@@ -1,0 +1,46 @@
+package no.nordicsemi.kotlin.data.logger
+
+import org.slf4j.LoggerFactory
+
+/**
+ * Default JVM [LogDelegate] that forwards entries to SLF4J.
+ *
+ * - [LogCategory.name] becomes the underlying SLF4J logger name, so backends
+ *   like Logback can route or filter per-category through their own config.
+ * - The `source` argument is prepended to the message as `"[source] ..."`.
+ *   It lands inside the message body deliberately: `slf4j-simple` (the
+ *   default backend wired in `data/build.gradle.kts`) has no MDC support.
+ *   If you swap in Logback and want a structured slot instead, write a
+ *   bespoke delegate that pushes `source` into MDC.
+ * - SLF4J's own per-logger threshold is consulted before [message] is
+ *   evaluated, so a category disabled at the SLF4J layer also pays no
+ *   string-construction cost.
+ */
+class Slf4jLogDelegate : LogDelegate {
+
+    override fun log(
+        category: LogCategory,
+        level: LogLevel,
+        source: String?,
+        message: () -> String,
+    ) {
+        val slf4j = LoggerFactory.getLogger(category.name)
+        val enabled = when (level) {
+            LogLevel.TRACE -> slf4j.isTraceEnabled
+            LogLevel.DEBUG -> slf4j.isDebugEnabled
+            LogLevel.INFO -> slf4j.isInfoEnabled
+            LogLevel.WARN -> slf4j.isWarnEnabled
+            LogLevel.ERROR -> slf4j.isErrorEnabled
+        }
+        if (!enabled) return
+
+        val text = if (source != null) "[$source] ${message()}" else message()
+        when (level) {
+            LogLevel.TRACE -> slf4j.trace(text)
+            LogLevel.DEBUG -> slf4j.debug(text)
+            LogLevel.INFO -> slf4j.info(text)
+            LogLevel.WARN -> slf4j.warn(text)
+            LogLevel.ERROR -> slf4j.error(text)
+        }
+    }
+}


### PR DESCRIPTION
## Summary                                                                                                                                                     
                                                                                                                                                                 
  Adds a Kotlin Multiplatform logging facade in                                                                                                                  
  `no.nordicsemi.kotlin.data.logger`:                                                                                                                            
                                                                                                                                                                 
  - **Lazy + level-gated.** `Logger.log(...)` takes `() -> String`; the                                                                                          
    lambda is invoked only after the configurable `minLevel` filter passes.                                                                                      
  - **Typed categories.** `LogCategory` is an interface, satisfied by any                                                                                        
    consumer enum: `enum class TransportLayer : LogCategory { HCI, GATT }`.                                                                                      
  - **First-class `source`.** Multiple producers (e.g. concurrently                                                                                              
    connected devices) can share one `Logger`; `source` is forwarded to                                                                                          
    the delegate as a structured field, not buried in the message body.                                                                                          
                                                                                                                                                                 
  All variability lives in `LogDelegate` — a `fun interface` with a single                                                                                       
  method `log(category, level, source, () -> message)`. Consumers plug any                                                                                       
  sink (SLF4J, NSLog, in-memory, test spy) without `expect/actual`.                                                                                              
                                                                                                                                                                 
  Defaults shipped: `Slf4jLogDelegate` (JVM, via newly-added `slf4j-simple`)                                                                                     
  and `NSLogDelegate` (Apple)

## Usage                                                                                                                                                       
                                                                                                                                                                 
  ```kotlin                                                                                                                                                      
  enum class TransportLayer : LogCategory { HCI, GATT, APPLICATION }                                                                                             
                                                                                                                                                                 
  val logger = Logger(Slf4jLogDelegate(), minLevel = LogLevel.DEBUG)                                                                                             
  logger.info(TransportLayer.GATT, source = device.address) {                                                                                                    
      "Notification: ${data.joinToString()}"                                                                                                                     
  }