### PR TITLE
Migration to Nordic Gradle Plugins 3.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
+    // This plugin is added here only for readability.
+    // It is automatically applied by the `libs.plugins.nordic.publish.kmp` plugin below.
     alias(libs.plugins.kotlin.multiplatform) apply false
-    alias(libs.plugins.nordic.kotlin.kmp) apply false
-    alias(libs.plugins.nordic.nexus.kmp) apply false
-
-    // This plugin is used to generate Dokka documentation.
-    alias(libs.plugins.kotlin.dokka) apply false
+    // Set the Kotlin version and JVM toolchain in one place for all modules, including KMP modules.
+    alias(libs.plugins.nordic.kotlin) apply false
+    // Required for publishing KMP modules on Maven Central.
+    alias(libs.plugins.nordic.publish.kmp) apply false
     // This applies Nordic look & feel to generated Dokka documentation.
     // https://github.com/NordicSemiconductor/Android-Gradle-Plugins/blob/main/plugins/src/main/kotlin/NordicDokkaPlugin.kt
     alias(libs.plugins.nordic.dokka) apply true

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -30,8 +30,9 @@
  */
 
 plugins {
-    alias(libs.plugins.nordic.kotlin.kmp)
-    alias(libs.plugins.nordic.nexus.kmp)
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.nordic.kotlin)
+    alias(libs.plugins.nordic.publish.kmp)
 }
 
 group = "no.nordicsemi.kotlin"
@@ -50,7 +51,7 @@ kotlin {
     }
 }
 
-nordicNexusPublishing {
+nordicPublishing {
     POM_ARTIFACT_ID = "data"
     POM_NAME = "Kotlin data utilities."
     POM_DESCRIPTION = "Set of extension methods for bit and byte-array operations."

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,8 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+# When configured, Gradle will run the build in incubating configuration cache mode.
+org.gradle.configuration-cache=true
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,8 @@ pluginManagement {
         google {
             content {
                 includeGroupAndSubgroups("com.google")
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("androidx")
             }
         }
         gradlePluginPortal {
@@ -34,7 +36,7 @@ dependencyResolutionManagement {
     versionCatalogs {
         // Use Nordic Gradle Version Catalog with common external libraries versions.
         create("libs") {
-            from("no.nordicsemi.android.gradle:version-catalog:2.15")
+            from("no.nordicsemi.gradle:version-catalog-min-sdk-21:3.0")
         }
     }
 }


### PR DESCRIPTION
The [Nordic Gradle Plugins 3.0](https://github.com/nordicsemi/Nordic-Gradle-Plugins/releases/tag/3.0) modified plugin IDs.

This PR migrates this project to use the new plugin structure.