### PR TITLE
Adding SPDX SBOM generation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,3 +26,4 @@ android.nonTransitiveRClass=true
 
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
+kotlin.native.ignoreDisabledTargets=true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,7 @@ pluginManagement {
                 includeGroupAndSubgroups("com.gradle")
                 includeGroupAndSubgroups("no.nordicsemi")
                 includeGroupAndSubgroups("org.jetbrains")
+                includeGroupAndSubgroups("org.spdx")
             }
         }
         mavenCentral()
@@ -38,7 +39,7 @@ dependencyResolutionManagement {
     versionCatalogs {
         // Use Nordic Gradle Version Catalog with common external libraries versions.
         create("libs") {
-            from("no.nordicsemi.gradle:version-catalog-min-sdk-21:3.0")
+            from("no.nordicsemi.gradle:version-catalog-min-sdk-21:3.1")
         }
     }
 }


### PR DESCRIPTION
This PR migrates to [Nordic Gradel Plugins 3.1](https://github.com/nordicsemi/Nordic-Gradle-Plugins/releases/tag/3.1) which now should generate a SPDX SBOM file in the main artifact on Maven. Fingers crossed!